### PR TITLE
condition for parallel downloads in curl

### DIFF
--- a/ghget
+++ b/ghget
@@ -18,6 +18,17 @@ while getopts :o: opt; do
 done
 shift $(($OPTIND - 1))
 
+
+version() {
+	printf "%s\n" "$1" | awk -F. '{ print $1*1e6 + $2*1e3 + $3 }'
+}
+
+curl_ver=$(curl -V | awk 'NR == 1 { print $2 }')
+parallel=
+if [ "$(version "$curl_ver")" -ge "$(version 7.66.0)" ]; then
+	parallel=-Z
+fi
+
 awk -F '>' -v RS='<' -v OFS='\t' '
 function get_path(url, parts, n, path, i) {
 	n = split(url, parts, "/")
@@ -98,7 +109,8 @@ BEGIN {
 	print_links(ARGV[1], ARGV[2])
 }
 ' "$name" "$1" "$out" | {
-	xargs -L4 curl --create-dirs --fail-early -fsSLZC - 2>&1 1>&3 3>&- |
+	xargs -L4 curl --create-dirs --fail-early $parallel -fsSLC - \
+		2>&1 1>&3 3>&- |
 	awk '
 		/error: 416/ { next }
 		/ignore/ { exit 1 }


### PR DESCRIPTION
Due from curl-7_66_0 and greater versions have recently introduced `--parallel` (-Z) feature
ghget stop downloading in older versions of this one.
Introduce a condition to execute curl with and without `-Z` parameter.

Just for the record.
Punctually the commit curl introduced this feat is `b88940850002a3f1c25bc6488b95ad30eb80d696`